### PR TITLE
Fix memory display

### DIFF
--- a/js/views/memory.js
+++ b/js/views/memory.js
@@ -42,7 +42,7 @@ var MemoryView = Backbone.View.extend({
 			$word = new MemWordView({ index: idx });
 			this.$words.push($word);
 			this.$wordContainer.append($word.$el);
-			idx += 10;
+			idx += 8;
 		}
 
 		this.numRendered = idx;


### PR DESCRIPTION
The render64 function was increasing the index by ten while only displaying eight bytes. Fixed by reducing the increment amount to eight.