### PR TITLE
Fix cmovge

### DIFF
--- a/js/instr.js
+++ b/js/instr.js
@@ -40,7 +40,7 @@ INSTR[2] = function () {
 		case 5:
 			// CMOVGE
 			if (SF === 0) {
-				getRegister(this.rB) = getRegister(this.rA);
+				REG[this.rB] = getRegister(this.rA);
 			}
 			break;
 		case 6:


### PR DESCRIPTION
cmovge gives error message "Invalid left-hand side in assignment", which was introduced by commit 09c768541adaaa336882b87a4ca0da1857f2a73b

Test code:
```
irmovq $0xabcd, %rdi

irmovq $11, %rcx
irmovq $3, %rdx

subq %rdx, %rcx
cmovge %rdi, %rax

halt
```