### PR TITLE
Fix inconsistency of condition codes with OPQ

### DIFF
--- a/js/instr.js
+++ b/js/instr.js
@@ -79,7 +79,7 @@ INSTR[6] = function () { // op
 	sgnA = !!(valA.toBytes()[0] & 0x80);
 	sgnB = !!(valB.toBytes()[0] & 0x80);
 	
-	OF = 0;
+	OF = 0; // clears OF. Only update OF when fn is ADD or SUB
 	
 	switch(this.fn) {
 		case 0:

--- a/js/instr.js
+++ b/js/instr.js
@@ -78,7 +78,9 @@ INSTR[6] = function () { // op
 
 	sgnA = !!(valA.toBytes()[0] & 0x80);
 	sgnB = !!(valB.toBytes()[0] & 0x80);
-
+	
+	OF = 0;
+	
 	switch(this.fn) {
 		case 0:
 			REG[this.rB] = REG[this.rB].add(getRegister(this.rA));


### PR DESCRIPTION
According to the CS:APP book 3rd edition, section 3.6.1, it is stated "For the logical operations, such as XOR, the carry and overflow flags are set to zero". To my understanding, other than not having the carry flag, y86 should have the same behavior on condition codes as x86.

Before, if you do something like an addq that sets the overflow flag, the xorq instruction does not clear it. This commit fixes the inconsistency by first setting OF to zero before going into the switch statement.